### PR TITLE
sync.yml: Avoid hanging on remote servers

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -12,12 +12,16 @@
   sudo: yes
   tasks:
   - apt: update_cache=yes
-  - apt: upgrade=dist
   - shell: dselect update
   - shell: dpkg --clear-selections
   - shell: dpkg --set-selections < /etc/packages.txt
   - shell: apt-get dselect-upgrade -qy
+    environment:
+      DEBIAN_FRONTEND: noninteractive
+  - apt: upgrade=dist
   - shell: aptitude purge -y -q ~c
+    environment:
+      DEBIAN_FRONTEND: noninteractive
 
 - name: update #! python packages to all servers
   hosts: shell-servers


### PR DESCRIPTION
This avoid apt opening interaction dialogs, and it applies the new package list before upgrading packages to avoid spurious etckeeper commits.

https://github.com/hashbang/shell-etc/pull/61 takes care of the remaining cases where an etckeeper commit might happen (and makes the play fail, rather than hang forever).
