### PR TITLE
sync.yml: Avoid using dselect

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -45,7 +45,7 @@
   become: true
   tasks:
   - apt: update_cache=yes
-  - shell: dselect update
+  - shell: apt-cache dumpavail | dpkg --update-avail
   - shell: dpkg --clear-selections
   - shell: dpkg --set-selections < /etc/packages.txt
   - shell: apt-get dselect-upgrade -qy


### PR DESCRIPTION
This avoids keeping around the dselect database, and `dselect` itself is largely unmaintained.
In particular, this solves the issue with `dselect` waiting for user input during an Ansible run.
