### PR TITLE
More fixes & push /etc to git-infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_script: pip install --user ansible ansible-lint
 script:
 - ansible-lint --exclude=roles/coreos-bootstrap coreos.yml
 - ansible-lint -x ANSIBLE0011 --exclude=roles/coreos-bootstrap credentials.yml
-- ansible-lint -x ANSIBLE0006,ANSIBLE0011 shell.yml
+- ansible-lint -x ANSIBLE0006 shell.yml

--- a/shell.yml
+++ b/shell.yml
@@ -2,6 +2,7 @@
 - name: Pull latest /etc files
   hosts: shell-servers
   become: true
+  gather_facts: false
   tasks:
     - block:
         - name: Create a temporary GNUPGHOME
@@ -37,6 +38,7 @@
 
 - name: Update/Sync system packages
   hosts: shell-servers
+  gather_facts: false
   become: true
   tasks:
     - name: Update apt cache

--- a/shell.yml
+++ b/shell.yml
@@ -26,6 +26,9 @@
     - command: etckeeper init
       when: etc.changed
 
+    - command: etckeeper push
+      when: etc.changed
+
 - name: Update/Sync system packages
   hosts: shell-servers
   become: true

--- a/shell.yml
+++ b/shell.yml
@@ -4,54 +4,66 @@
   become: true
   tasks:
     - block:
-        - command: mktemp -d
+        - name: Create a temporary GNUPGHOME
+          command: mktemp -d
           register: tmpdir
           changed_when: false
 
-        - copy:
+        - name: Copy the dummy GnuPG config
+          copy:
             src: gpg.conf
             dest: "{{ tmpdir.stdout + '/gpg.conf' }}"
           changed_when: false
 
-        - command: etckeeper vcs pull --ff-only --verify-signatures
+        - name: Pull changes and check signature
+          command: etckeeper vcs pull --ff-only --verify-signatures
           environment:
             GNUPGHOME: "{{ tmpdir.stdout }}"
           register: etc
           changed_when: "'Already up-to-date' not in etc.stdout"
 
       always:
-        - file: path={{ tmpdir.stdout }} state=absent
+        - name: Remove the temporary GNUPGHOME
+          file: path={{ tmpdir.stdout }} state=absent
           changed_when: false
 
-    - command: etckeeper init
+    - name: Apply file permissions in /etc
+      command: etckeeper init
       when: etc.changed
 
-    - command: etckeeper push
+    - name: Push new /etc state
+      command: etckeeper push
       when: etc.changed
 
 - name: Update/Sync system packages
   hosts: shell-servers
   become: true
   tasks:
-    - apt:   update_cache=yes
-    - shell: apt-cache dumpavail | dpkg --update-avail
+    - name: Update apt cache
+      apt:   update_cache=yes
+    - name: Update dpkg cache
+      shell: apt-cache dumpavail | dpkg --update-avail
       tags: [skip_ansible_lint]
 
     - block:
-        - command: dpkg --clear-selections
-        - shell:   dpkg --set-selections < /etc/packages.txt
-        - command: apt-get dselect-upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qy
+        - name: Set dpkg selections
+          shell:   dpkg --clear-selections && dpkg --set-selections < /etc/packages.txt
+        - name: Apply dpkg selections
+          command: apt-get dselect-upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qy
           environment:
             DEBIAN_FRONTEND: noninteractive
       when: etc.changed
 
-    - apt: upgrade=dist
+    - name: Upgrade packages
+      apt: upgrade=dist
       register: apt_upgrade
 
-    - command: aptitude purge -y -q ~c
+    - name: Purge uninstalled packages
+      command: aptitude purge -y -q ~c
       environment:
         DEBIAN_FRONTEND: noninteractive
       when: etc.changed or apt_upgrade.changed
 
-    - command: apt-get clean
+    - name: Clean the apt package cache
+      command: apt-get clean
       changed_when: false

--- a/shell.yml
+++ b/shell.yml
@@ -40,7 +40,7 @@
     - block:
         - command: dpkg --clear-selections
         - shell:   dpkg --set-selections < /etc/packages.txt
-        - command: apt-get dselect-upgrade -qy
+        - command: apt-get dselect-upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qy
           environment:
             DEBIAN_FRONTEND: noninteractive
       when: etc.changed

--- a/shell.yml
+++ b/shell.yml
@@ -6,39 +6,49 @@
     - block:
         - command: mktemp -d
           register: tmpdir
+          changed_when: false
+
         - copy:
             src: gpg.conf
             dest: "{{ tmpdir.stdout + '/gpg.conf' }}"
+          changed_when: false
+
         - command: etckeeper vcs pull --ff-only --verify-signatures
           environment:
             GNUPGHOME: "{{ tmpdir.stdout }}"
-          register: etc_result
-          changed_when: "'Already up-to-date' not in etc_result.stdout"
+          register: etc
+          changed_when: "'Already up-to-date' not in etc.stdout"
+
       always:
         - file: path={{ tmpdir.stdout }} state=absent
+          changed_when: false
 
     - command: etckeeper init
-      when: etc_result.changed
+      when: etc.changed
 
 - name: Update/Sync system packages
   hosts: shell-servers
   become: true
   tasks:
-    - apt:      update_cache=yes
-      register: apt_update
-    - shell:    apt-cache dumpavail | dpkg --update-avail
-      when:     apt_update.changed
+    - apt:   update_cache=yes
+    - shell: apt-cache dumpavail | dpkg --update-avail
+      tags: [skip_ansible_lint]
+
     - block:
         - command: dpkg --clear-selections
         - shell:   dpkg --set-selections < /etc/packages.txt
         - command: apt-get dselect-upgrade -qy
           environment:
             DEBIAN_FRONTEND: noninteractive
-      when: etc_result.changed
+      when: etc.changed
+
     - apt: upgrade=dist
-    - block:
-        - command: aptitude purge -y -q ~c
-          environment:
-            DEBIAN_FRONTEND: noninteractive
-        - command: apt-get clean
-      tags: [skip_ansible_lint]
+      register: apt_upgrade
+
+    - command: aptitude purge -y -q ~c
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      when: etc.changed or apt_upgrade.changed
+
+    - command: apt-get clean
+      changed_when: false


### PR DESCRIPTION
- This reports more accurately the “changed” status.
- This uses the changed status to skip unneeded tasks.
- Whenever `/etc` changes were pulled from `master`, update the state on `git-infra`.
