### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,67 +50,39 @@ This is expressed in the following `.ssh/config` snippet:
 
 ## Playbooks
 
-There are 3 playbooks present here:
+There are several playbooks present here:
 - `shell.yml` is used to synchronise the configuration (incl. installed packages)
   across the shell servers.
 - `credentials.yml` is used to deploy the admin's SSH keys across all servers:
   - admins can login as `root` on the shell servers;
   - they can login as `core` on the CoreOS servers.
 - `coreos.yml` performs CoreOS-specific tasks.  Currently, it only bootstraps
-  tha Ansible agent's dependencies.
+  the Ansible agent's dependencies.
+- `mail.yml` deploy the mail aliases and Postfix configuration.
+- `irc.yml` deploys static and templated configuration to the IRC servers,
+  including oper blocks for users defined in `group_vars/all/users.yml`.
 
 
 ## Usage
 
 ### Install a package
 
-  1. Connect to any shell server as yourself
-
-      ```bash
-      ssh you@ny1.hashbang.sh
-      ```
-
-  2. Install Package
-
-      ```bash
-      sudo apt-get install some-package
-      ```
-
-  3. Deploy changes on other servers
-
-      The configuration changes (including `packages.txt`) should have been
-      auto-pushed to `shell-etc`.  Now, you only need to re-sync the servers:
-
-      ```bash
-      ansible-playbook --ask-become-pass sync.yml
-      ```
+See `doc/Installing_packages.md`.
 
 
 ### Making a configuration change
 
-  1. Connect to any shell server as yourself
-
-      ```bash
-      ssh you@ny1.hashbang.sh
-      ```
-
-  2. Make and test any desired changes to files in /etc
-
-      ```bash
-      sudo vim /etc/some-config/file
-      ```
-
-  3. Commit changes via etckeeper
-
-      ```bash
-      sudo etckeeper commit -m 'updated some-config with some change'
-      ```
+ 1. Prepare your change for `shell-etc`, test it locally.
+ 2. Create a pull-request for it on Github, wait for a review.
+ 3. Performed a **signed** merge into `master`: `git merge -S --no-ff branch`  
+	Only merge into `master` things that you will deploy immediately.
+	Do not merge if you aren't in a position to follow-up with a deploy.
+ 4. Run the `shell.yml` playbook, see below.
 
 
-### Sync packages/config across all servers
+### Sync packages & configuration across all shell servers
 
-  1. Run Ansible playbook "sync"
-
-      ```bash
-      ansible-playbook --ask-become-pass -u your-sudo-user sync.yml
-      ```
+Simply run the appropriate Ansible playbook:
+```bash
+ansible-playbook -u root shell.yml
+```

--- a/doc/Add_SSH_key.md
+++ b/doc/Add_SSH_key.md
@@ -1,7 +1,8 @@
-# Adding SSH keys to a user
+# Adding SSH keys for a user
 
 **Note**: This is only for cases where, for some reason,
           `hashbangctl` is unavailable.
+		  Otherwise, `sudo -E SUDO_USER=foo hashbangctl` works.
 
 **Note**: Lines starting with `>` will be output from the command. Lines
 starting with `<` will be what you input to the command. Lines starting
@@ -12,13 +13,15 @@ After using an SSH client to access `ldap.hashbang.sh`, run the following comman
 ```sh
 $ read ldap_password
 < Input the password from `pass -c Hashbang/ldap_admin`; this will be copied to your clipboard.
-$ docker exec -i slapd ldapmodify -D "cn=admin,dc=hashbang,dc=sh" -w $ldap_password
+$ docker exec -i slapd ldapmodify -D "cn=admin,dc=hashbang,dc=sh" -w $ldap_password << EOF
 < dn: uid=<username>,ou=People,dc=hashbang,dc=sh
 < changetype: modify
 < add: sshPublicKey
 < sshPublicKey: <SSH Public Key>
-< <EOF (ctrl-d for most systems)>
+< EOF
 $ exit
 ```
 
-Next, double-check to make sure the shell key works. Make sure to notify the user.
+Next, check that logging in with the SSH key works.  Notify the user.
+
+Note that this does not remove previously-existing SSH keys.

--- a/doc/Blocking_account.md
+++ b/doc/Blocking_account.md
@@ -30,5 +30,5 @@ Using ansible:
 This invalidates that user's record in the SSS cache, then forcefully
 terminates the user's sessions (including all processes).
 
-Unfortunately, `terminate-user` does not dispatch a Russian mob
+Unfortunately, `terminate-user` does not send a Russian mob
 hitperson to dispatch the miscreant...

--- a/doc/Installing_packages.md
+++ b/doc/Installing_packages.md
@@ -1,36 +1,55 @@
 # Installing packages on the shell servers
 
-**NOTE**: This is a description of our current setup and of a possible workflow
-          you can use.  This isn't *prescriptive*.
+**NOTE**: This is a description of our current setup and of a possible
+          workflow you can use.  This isn't *prescriptive*.
+
 
 ## `etckeeper` and `shell-etc`
 
-The configuration present in the `/etc` directory of servers (with the exception
-  of local configuration and secrets) is kept in the [`shell-etc`] repository.
+The configuration present in the `/etc` directory of servers (with the
+  exception of local configuration and secrets) is kept in the
+  [`shell-etc`] repository.
 
-This includes a `packages.txt` file, which is a list of all package selections.
-That file is kept up-to-date using a post-install `etckeeper` hook located in
-  `etckeeper/post-install.d/00package-list`.
+This includes a `packages.txt` file, which is a list of all package
+  selections.  That file is kept up-to-date using a post-install
+  hook located in `etckeeper/post-install.d/00package-list`.
 
-It should not be edited by hand, as it must contain all needed dependencies.
-Moreover, packages installation (and upgrades) may modify `/etc`;  as such, the
-  most viable way to modify the package list is on a live server, using the
-  usual `apt` commands.
+It should not be edited by hand, as it must contain all needed
+  dependencies.  Moreover, packages installation (and upgrades) may
+  modify `/etc`; as such, the most viable way to modify the package
+  list is on a live server, using the usual `apt` commands, or on a
+  local mockup (using Docker, for instance).
+
+The current state of `/etc` in a shell server is always available in a
+  private Gitolite instance: `git-infra.hashbang.sh`.  Each server has
+  a branch on that remote, where only it can push (and cannot
+  force-push).
 
 [`shell-etc`]: https://github.com/hashbang/shell-etc
 
 
-## Pushing changes to `shell-etc`
+## Merging changes into `shell-etc`
 
-Once an `apt` run is sucessfully completed, `etckeeper` commits the result and
-  attempts to push it to [`shell-etc`].
+Once an `apt` run is sucessfully completed, `etckeeper` commits the
+result and pushes it to `git-infra.hashbang.sh`.
 
-The simplest way to do so is to have an SSH agent running (as your user, not as
-  `root`), with a SSH key loaded that can push to [`shell-etc`].  Note that the
-  key doesn't need to be on the server, SSH Agent forwarding and
-  [`ssh-agent-filter`] can be used to keep it safely client-side if desired.
+The simplest way to merge the change into `shell-etc` is to fetch it
+from `git-infra` and perform a regular git merge:
 
-Indeed, when running a command using `sudo`, the `${SSH_AUTH_SOCK}` environment
-  variable is preserved, letting `ssh` use your personal `ssh-agent`.
+	# Create the git-infra remote if you don't have it
+	git remote add git-infra git-infra.hashbang.sh:shell-etc.git
+	
+	# Fetch the changes
+	git fetch git-infra
+	
+	# Inspect the changes (here, coming form ny1.hashbang.sh)
+	tig git-infra/ny1 # Use your favorite tool there
+	
+	# Perform the merge and publish
+	git merge -S --no-ff git-infra/ny1
+	git push
 
-[`ssh-agent-filter`]: https://github.com/tiwe-de/ssh-agent-filter
+
+If the changes have been performed locally (for instance in a Docker
+mockup), the procedure is similar, but the changes obviously do not
+get pushed to `git-infra`.

--- a/doc/New_admin.md
+++ b/doc/New_admin.md
@@ -128,3 +128,11 @@ Still on `ldap.hashbang.sh`, with `HISTFILE` unset:
 	changetype: modify
 	add: memberUid
 	memberUid: $USER
+
+
+### Adding a user to the `team@` distribution list
+
+1. Edit `files/postfix/aliases`.
+2. Run the `mail.yml` playbook.
+3. Commit, pull request, signed merge.  
+   By now, you know the drill  ;)


### PR DESCRIPTION
- [x] Updates the package management procedures in `README` and `doc/`
  - sends to hell the SSH agent forwarding hack;
  - documents the use of `git-infra.hashbang.sh`.
- [x] Updates the list of playbooks.
- [x] Adds an update of the `team@` alias to the “New admin” procedure.
