### PR TITLE
gitignore *.retry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vault_newpassphrase.pgp
+*.retry


### PR DESCRIPTION
Those files are created by Ansible when a playbook fails, to allow re-running it only on the faulty machines.
They clearly don't belong in version control.