### PR TITLE
README: Remove unnecessary arguments to `ansible-playbook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ See `doc/Installing_packages.md`.
 
 Simply run the appropriate Ansible playbook:
 ```bash
-ansible-playbook -u root shell.yml
+ansible-playbook shell.yml
 ```


### PR DESCRIPTION
`ansible_user` is already set to `root` in the `hosts` file.