### PR TITLE
README: Remove unnecessary arguments to `ansible-playbook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ See `doc/Installing_packages.md`.
 
 Simply run the appropriate Ansible playbook:
 ```bash
-ansible-playbook -u root shell.yml
+ansible-playbook shell.yml
 ```


### PR DESCRIPTION
`ansible_user` is already set to `root` in the `hosts` file.

@KellerFuchs sorry I messed up https://github.com/hashbang/admin-tools/pull/67 by pressing a button in GH UI, which I shouldn't have.