### PR TITLE
vault_passphrase.sh: Allow input for GPG pinentry

### DIFF
--- a/.vault_newpassphrase.sh
+++ b/.vault_newpassphrase.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec gpg --batch --decrypt ".vault_newpassphrase.pgp" 2>/dev/null
+exec gpg --quiet --decrypt ".vault_newpassphrase.pgp"

--- a/vault_passphrase.sh
+++ b/vault_passphrase.sh
@@ -21,7 +21,7 @@ RECIPIENTS=(
 )
 
 if [ $# -eq 0 ]; then
-    exec gpg --batch --decrypt "${KEY_FILE}" 2>/dev/null
+    exec gpg --decrypt "${KEY_FILE}"
 
 elif [ $# -eq 1 ] && [ "$1" = "rekey" ]; then
     # Get 256b out of /dev/random, hex encoded

--- a/vault_passphrase.sh
+++ b/vault_passphrase.sh
@@ -21,7 +21,7 @@ RECIPIENTS=(
 )
 
 if [ $# -eq 0 ]; then
-    exec gpg --decrypt "${KEY_FILE}"
+    exec gpg --decrypt --quiet "${KEY_FILE}"
 
 elif [ $# -eq 1 ] && [ "$1" = "rekey" ]; then
     # Get 256b out of /dev/random, hex encoded


### PR DESCRIPTION
This removes the `--batch` option and enables output to `stderr [2]` when running `gpg` for decryption. This way, passwords can be entered for GPG keys and - if an error occurs - GPG output will be printed (which can be useful for debugging).