### PR TITLE
IRC: Do not rate-limit connections

### DIFF
--- a/files/unrealircd/unrealircd.conf.j2
+++ b/files/unrealircd/unrealircd.conf.j2
@@ -156,10 +156,10 @@ set {
 
     oper-only-stats "okfGsMRUEelLCXzdD";
 
-    throttle {
-        connections 3;
-        period 60s;
-    };
+#    throttle {
+#        connections 3;
+#        period 60s;
+#    };
 
     anti-flood {
         nick-flood 3:60;    /* 3 nickchanges per 60 seconds (the default) */


### PR DESCRIPTION
Otherwise, it takes quite a while for people to reconnect after an ircd drops.
Ideally, we would only lift the rate-limits for #! servers, but that's not supported.