### PR TITLE
ansible.cfg: Error-out on undefined variables

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -21,5 +21,9 @@ pipelining = True
 # Use a more generous SSH timeout (default: 10s)
 timeout = 30
 
+# Error-out when encountering an undefined variable
+# See https://docs.ansible.com/ansible/latest/intro_configuration.html#error-on-undefined-vars
+error_on_undefined_vars = True
+
 # Disabling the remnants of udderstuff
 nocows=1

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -5,7 +5,7 @@
   become: false
   vars:
     ldif: |
-      dn: uid={{ user }},ou=People,dc=hashbang,dc=sh
+      dn: uid={{ user | mandatory }},ou=People,dc=hashbang,dc=sh
       changetype: modify
       replace: loginShell
       loginShell: /usr/sbin/nologin


### PR DESCRIPTION
This sort of behaviour has been the cause for some very [high-profile bugs](https://github.com/valvesoftware/steam-for-linux/issues/3671) and is generally not a super-safe default.  It is always possible to use the [default](https://docs.ansible.com/ansible/latest/playbooks_filters.html#defaulting-undefined-variables) filter explicitely where this sort of behaviour is desired.