### PR TITLE
Travis: Script the lint check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,4 @@ git:
 before_script: pip install --user ansible ansible-lint
   
 script:
-- ansible-lint --exclude=roles/coreos-bootstrap coreos.yml
-- ansible-lint -x ANSIBLE0011 --exclude=roles/coreos-bootstrap credentials.yml
-- ansible-lint -x ANSIBLE0006 shell.yml
-- ansible-lint irc.yml
+- ./lint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 sudo: false
-dist: precise
-
-addons:
-  apt:
-    packages:
-    - python-pip
-
+language: python
 cache: pip
 
 git:
   depth: 3
 
-before_script: pip install --user ansible ansible-lint
+before_script: pip install ansible ansible-lint
   
 script:
 - ./lint.sh

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -9,11 +9,11 @@
       changetype: modify
       replace: loginShell
       loginShell: /usr/sbin/nologin
-      
+
   tasks:
     - name: Disable account in LDAP
       shell: echo "{{ ldif }}" | docker exec -i slapd ldapmodify -D {{ ldap.user }} -w {{ ldap.password }}
-      
+
 - hosts: shell_servers
   become: true
   strategy: free

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Global options
+declare -a OPTIONS=( -x ANSIBLE0011 --exclude=roles/coreos-bootstrap )
+
+# Per-file options
+declare -A F_OPTIONS=(
+    [shell.yml]="-x ANSIBLE0006"
+    [ldap_ban.yml]="-x ANSIBLE0012"
+)
+
+if ! command -v ansible-lint >/dev/null; then
+    echo "This script requires ansible-lint"
+    exit 1
+fi
+
+set -ex
+
+for playbook in *.yml; do
+    ansible-lint "${OPTIONS[@]}" ${F_OPTIONS[$playbook]} $playbook
+done

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Global options
 declare -a OPTIONS=( -x ANSIBLE0011 --exclude=roles/coreos-bootstrap )
 
@@ -9,13 +11,17 @@ declare -A F_OPTIONS=(
     [ldap_ban.yml]="-x ANSIBLE0012"
 )
 
+exec() {
+    echo '$' "$@"
+    "$@"
+}
+
+
 if ! command -v ansible-lint >/dev/null; then
     echo "This script requires ansible-lint"
     exit 1
 fi
 
-set -ex
-
 for playbook in *.yml; do
-    ansible-lint "${OPTIONS[@]}" ${F_OPTIONS[$playbook]} $playbook
+    exec ansible-lint "${OPTIONS[@]}" ${F_OPTIONS[$playbook]} $playbook
 done


### PR DESCRIPTION
This avoids repeating oneself, and prevents forgetting to add new playbooks to .travis.yml.