### PR TITLE
mail: Do not default to ${user}@hashbang.sh for the admin@ alias

### DIFF
--- a/files/postfix/aliases.j2
+++ b/files/postfix/aliases.j2
@@ -11,5 +11,5 @@ abuse: root
 noc: root
 security: root
 root: team
-team: {% for user in user_groups.admins %} {{ users[user].mail | default(user) }} {% endfor %}
+team: {% for user in user_groups.admins %} {{ users[user].mail | mandatory }} {% endfor %}
 

--- a/vault/users/main.yml
+++ b/vault/users/main.yml
@@ -11,7 +11,7 @@
 #  - unix: the username in LDAP, if different
 #  - irc_oper: an object with a type attribute (usually "sha1")
 #              and a pass attribute (usually the crypt(3)-format password).
-#  - mail: the user's email address; defaults to username@hashbang.sh
+#  - mail: the user's email address; required for admins
 
 
 user_groups:


### PR DESCRIPTION
There are currently some issues with pointing the alias towards @hashbang.sh mail addresses anyhow, so this default doesn't work.