### PR TITLE
credentials: Remove unmanaged SSH keys

### DIFF
--- a/credentials.yml
+++ b/credentials.yml
@@ -16,6 +16,7 @@
   tasks:
     - authorized_key:
         user: root
+        exclusive: True
         key: |
           {% for user in user_groups.admins %}
           {{ users[user].get('key') or lookup('file', 'files/keys/' + user + '.pub') }}


### PR DESCRIPTION
Fixup a bug introduced in #92, noticed by lrvick