### PR TITLE
Avoid strategy:free to produce more readable output

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -21,6 +21,9 @@ pipelining = True
 # Use a more generous SSH timeout (default: 10s)
 timeout = 30
 
+# Run on all hosts in parallel
+forks = 50
+
 # Error-out when encountering an undefined variable
 # See https://docs.ansible.com/ansible/latest/intro_configuration.html#error-on-undefined-vars
 error_on_undefined_vars = True

--- a/credentials.yml
+++ b/credentials.yml
@@ -4,7 +4,6 @@
 - name: Deploy SSH keys on CoreOS hosts
   hosts: coreos
   gather_facts: False
-  strategy: free
   roles:
     - coreos-bootstrap
     - role: coreos-authorized_keys

--- a/irc.yml
+++ b/irc.yml
@@ -4,7 +4,6 @@
 - name: Configure IRC servers
   hosts: irc_servers
   become: false
-  strategy: free
   tasks:
 #    # Does not work on CoreOS, due to the fucked up
 #    # Python install and lack of installable packages.

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -18,7 +18,6 @@
 
 - hosts: shell_servers
   become: true
-  strategy: free
   tasks:
     - name: Invalidate SSSd cache for {{ user }}
       command: sss_cache -u {{ user }}

--- a/shell.yml
+++ b/shell.yml
@@ -1,7 +1,6 @@
 # -*- eval: (ansible) -*-
 - name: Pull latest /etc files
   hosts: shell_servers
-  strategy: free
   tasks:
     - block:
         - name: Create a temporary GNUPGHOME
@@ -48,7 +47,6 @@
 - name: Update/Sync system packages
   hosts: shell_servers
   gather_facts: false
-  strategy: free
   tasks:
     - name: Update apt cache
       apt:   update_cache=yes


### PR DESCRIPTION
While `strategy: free` makes Ansible faster (by applying tasks to servers without waiting for the others to be done), the output gets pretty confusing.  Even when only dealing with a single server, Ansible seems to list the tasks' name _after_ they executed.

- [x] Remove all occurences of `strategy: free`.
- [x] Set higher parallelism to try to make up for the performance hit.