### PR TITLE
ldap_ban: Properly quote strings

### DIFF
--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -14,7 +14,10 @@
 
   tasks:
     - name: Disable account in LDAP
-      command: docker exec -i slapd ldapmodify -D {{ ldap.admin.dn }} -w {{ ldap.admin.password }}
+      command: >
+        docker exec -i slapd ldapmodify
+          -D {{ ldap.admin.dn       | quote }}
+          -w {{ ldap.admin.password | quote }}
       args:
         stdin: "{{ ldif }}"
 

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -14,7 +14,9 @@
 
   tasks:
     - name: Disable account in LDAP
-      shell: echo "{{ ldif }}" | docker exec -i slapd ldapmodify -D {{ ldap.admin.dn }} -w {{ ldap.admin.password }}
+      command: docker exec -i slapd ldapmodify -D {{ ldap.admin.dn }} -w {{ ldap.admin.password }}
+      args:
+        stdin: "{{ ldif }}"
 
 - hosts: shell_servers
   become: true


### PR DESCRIPTION
`ldap_ban.yml` otherwise fails.