### PR TITLE
shells: Fix shell-etc signature verification

### DIFF
--- a/shell.yml
+++ b/shell.yml
@@ -2,6 +2,10 @@
 - name: Pull latest /etc files
   hosts: shell_servers
   tasks:
+    - name: Fetch changes
+      command: etckeeper vcs fetch origin master
+      register: etc_fetch
+
     - block:
         - name: Create a temporary GNUPGHOME
           command: mktemp -d
@@ -18,27 +22,24 @@
               trust-model always
           changed_when: false
 
-        - name: Fetch changes
-          command: etckeeper vcs fetch origin master
-          register: etc_fetch
-
         - name: Check update signature
           command: etckeeper vcs verify-commit origin/master
           environment:
             GNUPGHOME: "{{ tmpdir.stdout }}"
-          when: etc_fetch.changed
 
         - name: Fast-forward changes
           command: etckeeper vcs merge --ff-only origin/master
           register: etc
           notify: etc changed
-          when: etc_fetch.changed
           changed_when: "'Already up-to-date' not in etc.stdout"
 
       always:
         - name: Remove the temporary GNUPGHOME
           file: path={{ tmpdir.stdout }} state=absent
           changed_when: false
+
+      when: etc_fetch.changed
+
 
   handlers:
     - name: etc changed

--- a/shell.yml
+++ b/shell.yml
@@ -18,12 +18,21 @@
               trust-model always
           changed_when: false
 
-        - name: Pull changes and check signature
-          command: etckeeper vcs pull --ff-only --verify-signatures
+        - name: Fetch changes
+          command: etckeeper vcs fetch origin master
+          register: etc_fetch
+
+        - name: Check update signature
+          command: etckeeper vcs verify-commit origin/master
           environment:
             GNUPGHOME: "{{ tmpdir.stdout }}"
+          when: etc_fetch.changed
+
+        - name: Fast-forward changes
+          command: etckeeper vcs merge --ff-only origin/master
           register: etc
           notify: etc changed
+          when: etc_fetch.changed
           changed_when: "'Already up-to-date' not in etc.stdout"
 
       always:

--- a/shell.yml
+++ b/shell.yml
@@ -4,7 +4,11 @@
   tasks:
     - name: Fetch changes
       command: etckeeper vcs fetch origin master
-      register: etc_fetch
+
+    - name: Get commit hashes
+      command: etckeeper vcs rev-parse HEAD origin/master
+      register: etc_hashes
+      changed_when: False
 
     - block:
         - name: Create a temporary GNUPGHOME
@@ -23,12 +27,12 @@
           changed_when: false
 
         - name: Check update signature
-          command: etckeeper vcs verify-commit origin/master
+          command: etckeeper vcs verify-commit {{ etc_hashes.stdout_lines[1] }}
           environment:
             GNUPGHOME: "{{ tmpdir.stdout }}"
 
         - name: Fast-forward changes
-          command: etckeeper vcs merge --ff-only origin/master
+          command: etckeeper vcs merge --ff-only {{ etc_hashes.stdout_lines[1] }}
           register: etc
           notify: etc changed
           changed_when: "'Already up-to-date' not in etc.stdout"
@@ -38,7 +42,7 @@
           file: path={{ tmpdir.stdout }} state=absent
           changed_when: false
 
-      when: etc_fetch.changed
+      when: etc_hashes.stdout_lines[0] != etc_hashes.stdout_lines[1]
 
 
   handlers:

--- a/shell.yml
+++ b/shell.yml
@@ -3,7 +3,9 @@
   hosts: shell_servers
   tasks:
     - name: Fetch changes
-      command: etckeeper vcs fetch origin master
+      command: etckeeper vcs fetch -v origin master
+      register: fetch
+      changed_when: "'up-to-date' not in fetch.stdout"
 
     - name: Get commit hashes
       command: etckeeper vcs rev-parse HEAD origin/master


### PR DESCRIPTION
This fixes a non-security bug, that prevented deploying updates after merging in `shell-etc` locally-generated commits.