### PR TITLE
Setup benharri's admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is expressed in the following `.ssh/config` snippet:
 	Host git-infra.hashbang.sh
 	     User git
 
-	Host sfo1.irc.hashbang.sh
+	Host sfo1.irc.hashbang.sh ldap.hashbang.sh
 	     User core
 
 	Host *.hashbang.sh hashbang.sh

--- a/hosts
+++ b/hosts
@@ -14,7 +14,7 @@ ansible_user=root
 [coreos]
 hashbang.sh
 im.hashbang.sh
-ldap.hashbang.sh
+ldap.hashbang.sh ansible_port=22
 mail.hashbang.sh
 nyc3.apps.hashbang.sh
 voip.hashbang.sh

--- a/vault/users/main.yml
+++ b/vault/users/main.yml
@@ -48,7 +48,6 @@ users:
     irc_oper:
       type: sslclientcertfp
       pass: "90:7F:08:66:21:06:18:A8:29:6A:44:15:F9:FA:AB:D6:DF:A5:06:6A:05:69:4D:DA:C2:78:F7:20:E6:5E:88:92"
-    mail: "{{ vault_users.benharri.mail }}"
 
   daurnimator:
     irc_oper:


### PR DESCRIPTION
@benharri `credentials.yml` did not run cleanly due to the `users.benharri` object containing stuff that couldn't be evaluated.

I already deployed this, so you should have all required access; after merging, add to `user.benharri` a `mail` property and run the `mail.yml` playbook.