### PR TITLE
Improve the ldap_ban playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ There are several playbooks present here:
 		ansible-playbook ldap_ban.yml
 
   For scripting purposes, the script accepts a comma-separated list of users,
-  as parameter `users`.
+  (`users`), and a Boolean determining if the homedirs should be deleted
+  (`delete`).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ There are several playbooks present here:
   sessions on the shell servers; it requires python-ldap installed.
   Invoke as follows:
 
-		ansible-playbook ldap_ban.yml -e 'users=${USERNAME}'
+		ansible-playbook ldap_ban.yml
 
-  `users` can be a comma-separated list of users.
+  For scripting purposes, the script accepts a comma-separated list of users,
+  as parameter `users`.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ There are several playbooks present here:
 - `irc.yml` deploys static and templated configuration to the IRC servers,
   including oper blocks for users defined in `group_vars/all/users.yml`.
 - `ldap_ban.yml` disables a user's account in LDAP and terminate their
-  sessions on the shell servers.  Invoke as follows:
+  sessions on the shell servers; it requires python-ldap installed.
+  Invoke as follows:
 
 		ansible-playbook ldap_ban.yml -e 'user=${USERNAME}'
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ There are several playbooks present here:
 - `mail.yml` deploy the mail aliases and Postfix configuration.
 - `irc.yml` deploys static and templated configuration to the IRC servers,
   including oper blocks for users defined in `group_vars/all/users.yml`.
-- `ldap_ban.yml` disables a user's account in LDAP and terminate their
+- `ldap_ban.yml` disables user accounts in LDAP and terminates their
   sessions on the shell servers; it requires python-ldap installed.
   Invoke as follows:
 
-		ansible-playbook ldap_ban.yml -e 'user=${USERNAME}'
+		ansible-playbook ldap_ban.yml -e 'users=${USERNAME}'
+
+  `users` can be a comma-separated list of users.
 
 
 ## Usage

--- a/doc/Blocking_account.md
+++ b/doc/Blocking_account.md
@@ -4,10 +4,13 @@ Sadly, sometimes abuse happen.
 Sometimes, admins are required to block a user's account.  
 Sometimes, there is automation for it.
 
-	ansible-playbook ldap_ban.yml -e 'user=dude55b1'
+	ansible-playbook ldap_ban.yml
 
-The playbook will take care of disabling the account and
-kicking the user from all shell servers.
+The playbook will take care of disabling the account and kicking the user from
+all shell servers. By default, it prompts for the list of users to ban, unless a
+colon-separated list is provided on the command line:
+
+	ansible-playbook ldap_ban.yml -e users=dude55b1,kellertest,lrobovick
 
 
 # How the sausage is made

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -54,7 +54,7 @@
       failed_when: |
         'Could not terminate user: No user' not in terminate.stderr
         and terminate is failed
-      changed_when: terminate.stderr == "" and terminate|success
+      changed_when: terminate.stderr == "" and terminate is success
 
     - name: Delete home directories
       when: delete_homedirs

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -1,25 +1,20 @@
 # -*- eval: (ansible) -*-
 - include: vault.yml load=ldap hosts=ldap.hashbang.sh
 
-# This is a sucky way to make LDAP changes,
-# but Ansible's ldap_attr module is v2.3 only
-- hosts: ldap.hashbang.sh
-  become: false
-  vars:
-    ldif: |
-      dn: uid={{ user | mandatory }},ou=People,dc=hashbang,dc=sh
-      changetype: modify
-      replace: loginShell
-      loginShell: /usr/sbin/nologin
-
+- name: Disable the account in LDAP
+  hosts: ldap.hashbang.sh
+  gather_facts: False
   tasks:
-    - name: Disable account in LDAP
-      command: >
-        docker exec -i slapd ldapmodify
-          -D {{ ldap.admin.dn       | quote }}
-          -w {{ ldap.admin.password | quote }}
-      args:
-        stdin: "{{ ldif }}"
+    - ldap_attr:
+        server_uri: ldaps://ldap.hashbang.sh
+        bind_dn: "{{ ldap.admin.dn }}"
+        bind_pw: "{{ ldap.admin.password }}"
+
+        dn: uid={{ user | mandatory }},ou=People,dc=hashbang,dc=sh
+        name: loginShell
+        state: exact
+        values: /usr/sbin/nologin
+      delegate_to: localhost
 
 - hosts: shell_servers
   become: true

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -4,6 +4,12 @@
 - name: Parse parameters
   hosts: ldap.hashbang.sh,shell_servers
   gather_facts: no
+
+  vars_prompt:
+    - name: users
+      prompt: Comma-separated list of users to ban
+      private: no
+
   tasks:
     - name: Parse users list
       set_fact:
@@ -11,7 +17,7 @@
 
 - name: Disable the account in LDAP
   hosts: ldap.hashbang.sh
-  gather_facts: False
+  gather_facts: no
   tasks:
     - ldap_attr:
         server_uri: ldaps://ldap.hashbang.sh

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -10,10 +10,16 @@
       prompt: Comma-separated list of users to ban
       private: no
 
+    - name: delete
+      prompt: Delete home directories? (yes/no)
+      private: no
+      default: "no"
+
   tasks:
     - name: Parse users list
       set_fact:
         user_list: "{{ users.split(',') }}"
+        delete_homedirs: "{{ delete }}"
 
 - name: Disable the account in LDAP
   hosts: ldap.hashbang.sh
@@ -49,3 +55,10 @@
         'Could not terminate user: No user' not in terminate.stderr
         and terminate|failed
       changed_when: terminate.stderr == "" and terminate|success
+
+    - name: Delete home directories
+      when: delete_homedirs
+      with_items: "{{ user_list }}"
+      file:
+        path: /home/{{ item }}
+        state: absent

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -1,6 +1,14 @@
 # -*- eval: (ansible) -*-
 - include: vault.yml load=ldap hosts=ldap.hashbang.sh
 
+- name: Parse parameters
+  hosts: ldap.hashbang.sh,shell_servers
+  gather_facts: no
+  tasks:
+    - name: Parse users list
+      set_fact:
+        user_list: "{{ users.split(',') }}"
+
 - name: Disable the account in LDAP
   hosts: ldap.hashbang.sh
   gather_facts: False
@@ -10,23 +18,27 @@
         bind_dn: "{{ ldap.admin.dn }}"
         bind_pw: "{{ ldap.admin.password }}"
 
-        dn: uid={{ user | mandatory }},ou=People,dc=hashbang,dc=sh
+        dn: uid={{ item }},ou=People,dc=hashbang,dc=sh
         name: loginShell
         state: exact
         values: /usr/sbin/nologin
       delegate_to: localhost
+      with_items: "{{ user_list }}"
 
 - hosts: shell_servers
   become: true
+  gather_facts: no
   tasks:
-    - name: Invalidate SSSd cache for {{ user }}
-      command: sss_cache -u {{ user }}
+    - name: Invalidate SSSd cache entries
+      command: sss_cache -u {{ item }}
+      with_items: "{{ user_list }}"
       changed_when: false
       ignore_errors: yes
 
-    - name: Terminate sessions for {{ user }}
-      command: loginctl terminate-user {{ user }}
+    - name: Terminate user sessions
+      command: loginctl terminate-user {{ item }}
       register: terminate
+      with_items: "{{ user_list }}"
       failed_when: |
         'Could not terminate user: No user' not in terminate.stderr
         and terminate|failed

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -53,7 +53,7 @@
       with_items: "{{ user_list }}"
       failed_when: |
         'Could not terminate user: No user' not in terminate.stderr
-        and terminate|failed
+        and terminate is failed
       changed_when: terminate.stderr == "" and terminate|success
 
     - name: Delete home directories

--- a/ldap_ban.yml
+++ b/ldap_ban.yml
@@ -22,6 +22,7 @@
     - name: Invalidate SSSd cache for {{ user }}
       command: sss_cache -u {{ user }}
       changed_when: false
+      ignore_errors: yes
 
     - name: Terminate sessions for {{ user }}
       command: loginctl terminate-user {{ user }}


### PR DESCRIPTION
- [x] Use `ldap_attr` rather than running a raw command on `ldap.hashbang.sh`.
- [x] Ignore errors from `sss_cache`.
  It turns out it can spuriously error-out.  Wheee, quality software \o/
- [x] Support banning multiple users at once.
- [x] Support (optionally) deleting the users' home directories.
- [x] Prompt the administrator interactively for options.