### PR TITLE
terraform/r53: remove dead DNS records

### DIFF
--- a/terraform/modules/r53/main.tf
+++ b/terraform/modules/r53/main.tf
@@ -19,14 +19,6 @@ resource "aws_route53_record" "sfo1-irc-ipv4" {
     records = ["107.170.252.157"]
 }
 
-resource "aws_route53_record" "lon1-irc-ipv4" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "lon1.irc.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["178.62.33.133"]
-}
-
 resource "aws_route53_record" "userdb-ipv4" {
     zone_id = "${aws_route53_zone.hashbang.zone_id}"
     name = "userdb.${aws_route53_zone.hashbang.name}"
@@ -71,20 +63,6 @@ resource "aws_route53_record" "irc-ipv4-us" {
     health_check_id = "${aws_route53_health_check.irc-us.id}"
 }
 
-resource "aws_route53_record" "irc-ipv4-eu" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "irc.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["178.62.33.133"]
-
-    set_identifier = "eu"
-    geolocation_routing_policy {
-    	continent = "EU"
-    }
-    health_check_id = "${aws_route53_health_check.irc-eu.id}"
-}
-
 // HEALTHCHECKS
 resource "aws_route53_health_check" "irc-us" {
   ip_address        = "107.170.252.157"
@@ -96,34 +74,6 @@ resource "aws_route53_health_check" "irc-us" {
   tags = {
     Name = "tf-irc-us"
   }
-}
-
-resource "aws_route53_health_check" "irc-eu" {
-  ip_address        = "178.62.33.133"
-  port              = 6697
-  type              = "TCP"
-  failure_threshold = "5"
-  request_interval  = "30"
-
-  tags = {
-    Name = "tf-irc-eu"
-  }
-}
-
-// A + AAAA PAIRS
-resource "aws_route53_record" "ldap-ipv6" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "ldap.${aws_route53_zone.hashbang.name}"
-    type = "AAAA"
-    ttl  = "1800"
-    records = ["2604:a880:800:a1::1295:f001"]
-}
-resource "aws_route53_record" "ldap-ipv4" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "ldap.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["165.227.96.208"]
 }
 
 resource "aws_route53_record" "de1-ipv6" {
@@ -276,21 +226,6 @@ resource "aws_route53_record" "to1-ipv4-wildcard" {
     records = ["46.4.114.111"]
 }
 
-resource "aws_route53_record" "services-irc-ipv6" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "services.irc.${aws_route53_zone.hashbang.name}"
-    type = "AAAA"
-    ttl  = "1800"
-    records = ["2604:a880:800:10::120a:7001"]
-}
-resource "aws_route53_record" "services-irc-ipv4" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "services.irc.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["45.55.71.38"]
-}
-
 resource "aws_route53_record" "im-ipv6" {
     zone_id = "${aws_route53_zone.hashbang.zone_id}"
     name = "im.${aws_route53_zone.hashbang.name}"
@@ -336,21 +271,6 @@ resource "aws_route53_record" "hashbang-ipv4" {
     records = ["104.131.13.197"]
 }
 
-resource "aws_route53_record" "voip-ipv6" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "voip.${aws_route53_zone.hashbang.name}"
-    type = "AAAA"
-    ttl  = "1800"
-    records = ["2604:a880:2:d0::17d:6001"]
-}
-resource "aws_route53_record" "voip-ipv4" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "voip.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["138.68.57.139"]
-}
-
 resource "aws_route53_record" "nyc3-apps-ipv6" {
     zone_id = "${aws_route53_zone.hashbang.zone_id}"
     name = "nyc3.apps.${aws_route53_zone.hashbang.name}"
@@ -394,14 +314,6 @@ resource "aws_route53_record" "va1-alias" {
   records = ["ny1.${aws_route53_zone.hashbang.name}"]
 }
 
-resource "aws_route53_record" "git-infra-alias" {
-  zone_id = "${aws_route53_zone.hashbang.zone_id}"
-  name = "git-infra.${aws_route53_zone.hashbang.name}"
-  type = "CNAME"
-  ttl = "1800"
-  records = ["nyc3.apps.${aws_route53_zone.hashbang.name}"]
-}
-
 // MX
 resource "aws_route53_record" "mx" {
     zone_id = "${aws_route53_zone.hashbang.zone_id}"
@@ -411,20 +323,4 @@ resource "aws_route53_record" "mx" {
     records = [
         "10 mail.${aws_route53_zone.hashbang.name}"
     ]
-}
-
-// temporary?
-resource "aws_route53_record" "brokenchat-ipv6" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "brokenchat.${aws_route53_zone.hashbang.name}"
-    type = "AAAA"
-    ttl  = "1800"
-    records = ["2604:a880:800:10::189c:f001"]
-}
-resource "aws_route53_record" "brokenchat-ipv4" {
-    zone_id = "${aws_route53_zone.hashbang.zone_id}"
-    name = "brokenchat.${aws_route53_zone.hashbang.name}"
-    type = "A"
-    ttl  = "1800"
-    records = ["45.55.162.19"]
 }


### PR DESCRIPTION
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.r53.aws_route53_health_check.irc-eu will be destroyed
  - resource "aws_route53_health_check" "irc-eu" {
      - child_health_threshold = 0 -> null
      - child_healthchecks     = [] -> null
      - enable_sni             = false -> null
      - failure_threshold      = 5 -> null
      - id                     = "157d55bf-4359-4be6-b12a-4062b1e4d3d7" -> null
      - invert_healthcheck     = false -> null
      - ip_address             = "178.62.33.133" -> null
      - measure_latency        = false -> null
      - port                   = 6697 -> null
      - regions                = [] -> null
      - request_interval       = 30 -> null
      - tags                   = {
          - "Name" = "tf-irc-eu"
        } -> null
      - type                   = "TCP" -> null
    }

  # module.r53.aws_route53_record.brokenchat-ipv4 will be destroyed
  - resource "aws_route53_record" "brokenchat-ipv4" {
      - allow_overwrite = true -> null
      - fqdn            = "brokenchat.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_brokenchat.hashbang.sh_A" -> null
      - name            = "brokenchat.hashbang.sh" -> null
      - records         = [
          - "45.55.162.19",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.brokenchat-ipv6 will be destroyed
  - resource "aws_route53_record" "brokenchat-ipv6" {
      - allow_overwrite = true -> null
      - fqdn            = "brokenchat.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_brokenchat.hashbang.sh_AAAA" -> null
      - name            = "brokenchat.hashbang.sh" -> null
      - records         = [
          - "2604:a880:800:10::189c:f001",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "AAAA" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.git-infra-alias will be destroyed
  - resource "aws_route53_record" "git-infra-alias" {
      - allow_overwrite = true -> null
      - fqdn            = "git-infra.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_git-infra.hashbang.sh_CNAME" -> null
      - name            = "git-infra.hashbang.sh" -> null
      - records         = [
          - "nyc3.apps.hashbang.sh.",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "CNAME" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.irc-ipv4-eu will be destroyed
  - resource "aws_route53_record" "irc-ipv4-eu" {
      - allow_overwrite = true -> null
      - fqdn            = "irc.hashbang.sh" -> null
      - health_check_id = "157d55bf-4359-4be6-b12a-4062b1e4d3d7" -> null
      - id              = "Z3L6CE91UO1ZUB_irc.hashbang.sh_A_eu" -> null
      - name            = "irc.hashbang.sh" -> null
      - records         = [
          - "178.62.33.133",
        ] -> null
      - set_identifier  = "eu" -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null

      - geolocation_routing_policy {
          - continent = "EU" -> null
        }
    }

  # module.r53.aws_route53_record.ldap-ipv4 will be destroyed
  - resource "aws_route53_record" "ldap-ipv4" {
      - allow_overwrite = true -> null
      - fqdn            = "ldap.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_ldap.hashbang.sh_A" -> null
      - name            = "ldap.hashbang.sh" -> null
      - records         = [
          - "165.227.96.208",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.ldap-ipv6 will be destroyed
  - resource "aws_route53_record" "ldap-ipv6" {
      - allow_overwrite = true -> null
      - fqdn            = "ldap.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_ldap.hashbang.sh_AAAA" -> null
      - name            = "ldap.hashbang.sh" -> null
      - records         = [
          - "2604:a880:800:a1::1295:f001",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "AAAA" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.lon1-irc-ipv4 will be destroyed
  - resource "aws_route53_record" "lon1-irc-ipv4" {
      - allow_overwrite = true -> null
      - fqdn            = "lon1.irc.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_lon1.irc.hashbang.sh_A" -> null
      - name            = "lon1.irc.hashbang.sh" -> null
      - records         = [
          - "178.62.33.133",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.services-irc-ipv4 will be destroyed
  - resource "aws_route53_record" "services-irc-ipv4" {
      - allow_overwrite = true -> null
      - fqdn            = "services.irc.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_services.irc.hashbang.sh_A" -> null
      - name            = "services.irc.hashbang.sh" -> null
      - records         = [
          - "45.55.71.38",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.services-irc-ipv6 will be destroyed
  - resource "aws_route53_record" "services-irc-ipv6" {
      - allow_overwrite = true -> null
      - fqdn            = "services.irc.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_services.irc.hashbang.sh_AAAA" -> null
      - name            = "services.irc.hashbang.sh" -> null
      - records         = [
          - "2604:a880:800:10::120a:7001",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "AAAA" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.voip-ipv4 will be destroyed
  - resource "aws_route53_record" "voip-ipv4" {
      - allow_overwrite = true -> null
      - fqdn            = "voip.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_voip.hashbang.sh_A" -> null
      - name            = "voip.hashbang.sh" -> null
      - records         = [
          - "138.68.57.139",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "A" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }

  # module.r53.aws_route53_record.voip-ipv6 will be destroyed
  - resource "aws_route53_record" "voip-ipv6" {
      - allow_overwrite = true -> null
      - fqdn            = "voip.hashbang.sh" -> null
      - id              = "Z3L6CE91UO1ZUB_voip.hashbang.sh_AAAA" -> null
      - name            = "voip.hashbang.sh" -> null
      - records         = [
          - "2604:a880:2:d0::17d:6001",
        ] -> null
      - ttl             = 1800 -> null
      - type            = "AAAA" -> null
      - zone_id         = "Z3L6CE91UO1ZUB" -> null
    }
```